### PR TITLE
Add no L1GT protection in ClusterTask

### DIFF
--- a/DQM/EcalMonitorTasks/src/ClusterTask.cc
+++ b/DQM/EcalMonitorTasks/src/ClusterTask.cc
@@ -105,10 +105,12 @@ namespace ecaldqm
     _es.get<L1GtTriggerMenuRcd>().get(menuRcd) ;
     L1GtTriggerMenu const* menu(menuRcd.product());
 
-    for(unsigned iT(0); iT != egTriggerAlgos_.size(); ++iT){
-      if(menu->gtAlgorithmResult(egTriggerAlgos_[iT], dWord)){
-        triggered_.set(kEcalTrigger);
-        break;
+    if ( dWord.size() > 0)  { //protect against no L1GT in run
+      for(unsigned iT(0); iT != egTriggerAlgos_.size(); ++iT){
+        if(menu->gtAlgorithmResult(egTriggerAlgos_[iT], dWord)){
+          triggered_.set(kEcalTrigger);
+          break;
+        }
       }
     }
 


### PR DESCRIPTION
Add protection for no L1GT when running Cluster Task (https://github.com/cms-sw/cmssw/commit/ccfdb26e3a70791bfb7c86ae58fe14c404f4e399)
